### PR TITLE
Provide just a build target in Gruntfile.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,4 +108,5 @@ module.exports = function(grunt) {
   
   grunt.registerTask("test", ["shell:mocha"]);
   grunt.registerTask("start", ["sass", "babel", "concurrent"]);
+  grunt.registerTask("build", ["sass", "babel"]);
 };

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ cd cog
 npm install
 
 grunt start # spin up nginx @localhost:8000, start watch over scss && js files
+# --- OR ---
+grunt build # in case a separate web server is used, just build the project
 ```
 - Navigate to [http://localhost:8000](http://localhost:8000 "Cog @ localhost")
 


### PR DESCRIPTION
If a separate web server is used, one might not want to actually start nginx.
